### PR TITLE
Enhance problematic-translogs with adaptive thresholds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Enhanced `problematic-translogs` command**: Adaptive threshold detection based on table settings
+  - Default `--sizeMB` changed from 300MB to 512MB (CrateDB default flush threshold)
+  - Adaptive thresholds: Uses table-specific `flush_threshold_size * 1.1` for intelligent detection
+  - Performance optimized: Only queries table settings for tables with initially problematic shards
+  - Enhanced display: Shows both configured value and calculated threshold (e.g., "2048MB/2253MB config/threshold")
+  - Partition support: Handles partition-specific flush_threshold_size settings
+  - Clean CLI: Simplified help text for better usability
+  - Fixed REROUTE CANCEL commands to include partition information for partitioned tables
+
 - **First loguru integration**: `read-check` is the first command to use structured logging
 - **Enhanced per-table statistics**: Shows document change tracking and performance metrics
   - Document changes: Total change with min/avg/max deltas

--- a/QUERIES.md
+++ b/QUERIES.md
@@ -824,3 +824,30 @@ FROM information_schema.tables
 WHERE settings['merge']['scheduler']['max_thread_count'] = 1;
 
 ```
+
+cr> SELECT
+table_schema,
+table_name,
+partitioned_by, settings['translog']['flush_threshold_size']
+FROM information_schema.tables
+WHERE table_name = 'orderFormFieldData';
++--------------+--------------------+----------------+----------------------------------------------+
+| table_schema | table_name | partitioned_by | settings['translog']['flush_threshold_size'] |
++--------------+--------------------+----------------+----------------------------------------------+
+| TURVO | orderFormFieldData | NULL | 2147483648 |
++--------------+--------------------+----------------+----------------------------------------------+
+SELECT 1 row in set (0.232 sec)
+cr> SELECT
+table_schema,
+table_name,
+partitioned_by, settings['translog']['flush_threshold_size']
+FROM information_schema.tables
+WHERE table_name = 'account';
++--------------------------------+------------+----------------+----------------------------------------------+
+| table_schema | table_name | partitioned_by | settings['translog']['flush_threshold_size'] |
++--------------------------------+------------+----------------+----------------------------------------------+
+| TURVO_MySQL | account | NULL | 536870912 |
+| replication_third_materialized | account | NULL | 536870912 |
++--------------------------------+------------+----------------+----------------------------------------------+
+SELECT 2 rows in set (0.226 sec)
+cr>


### PR DESCRIPTION
 **Enhanced `problematic-translogs` command**: Adaptive threshold detection based on table settings
  - Default `--sizeMB` changed from 300MB to 512MB (CrateDB default flush threshold)
  - Adaptive thresholds: Uses table-specific `flush_threshold_size * 1.1` for intelligent detection
  - Performance optimized: Only queries table settings for tables with initially problematic shards
  - Enhanced display: Shows both configured value and calculated threshold (e.g., "2048MB/2253MB config/threshold")
  - Partition support: Handles partition-specific flush_threshold_size settings
  - Clean CLI: Simplified help text for better usability
  - Fixed REROUTE CANCEL commands to include partition information for partitioned tables
