### PR TITLE
CI: Publish OCI builds to GHCR, staged through GHA

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 *
+!*.md
 !config
 !docs
-!src
-!*.md
+!LICENSE
 !pyproject.toml
+!release
+!src

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -1,0 +1,141 @@
+# Stage OCI container images through GitHub Actions (GHA) to GitHub Container Registry (GHCR).
+name: OCI
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  pull_request:
+    # branches: [ main ]
+
+  schedule:
+    - cron: '0 06 * * *' # every day at 06am
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+permissions:
+  # Permit pushing to GHCR.
+  contents: read
+  packages: write
+  # Enable signed provenance/attestations.
+  id-token: write
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+# The name for the produced image at ghcr.io.
+env:
+  IMAGE_NAME: "${{ github.repository }}"
+
+jobs:
+
+  build-wheel:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          architecture: "x64"
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
+
+      - name: Build wheel package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Upload wheel package
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ runner.os }}-wheel-${{ github.sha }}
+          path: dist/*.whl
+          retention-days: 7
+
+      - name: Run tests
+        run: |
+          if [[ -f release/oci/test.yml ]]; then
+            export DOCKER_BUILDKIT=1
+            export COMPOSE_DOCKER_CLI_BUILD=1
+            docker compose --file release/oci/test.yml build
+            docker compose --file release/oci/test.yml run --rm sut
+          fi
+
+  build-oci:
+    needs: build-wheel
+    runs-on: ubuntu-latest
+    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Define image name and tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # List of OCI images to use as base name for tags
+          images: |
+            ghcr.io/${{ env.IMAGE_NAME }}
+          # Generate OCI image tags based on the following events/attributes
+          tags: |
+            type=schedule,pattern=nightly
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Inspect metadata
+        run: |
+          echo "Tags:      ${{ steps.meta.outputs.tags }}"
+          echo "Labels:    ${{ steps.meta.outputs.labels }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,compression=zstd
+          sbom: true
+          provenance: mode=max
+
+      - name: Display git status
+        run: |
+          set -x
+          git describe --tags --always
+          git status

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR /app
 
 # Copy application code
-COPY --chown=xmover:xmover src/ ./src/
-COPY --chown=xmover:xmover pyproject.toml README.md ./
+COPY --chown=xmover:xmover . .
 
 # Install application in editable mode
 # TODO: Why not install the wheel package from the previous build step?
@@ -73,6 +72,9 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # Set default command
 ENTRYPOINT ["xmover"]
 CMD ["--help"]
+
+# Copy selftest.sh to the image
+COPY release/oci/selftest.sh /usr/local/bin
 
 # Labels for metadata
 LABEL org.opencontainers.image.title="XMover"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ XLens is a comprehensive looking-glass utility for analyzing CrateDB clusters.
 ## Install
 
 Install package from Git repository.
-
 ```shell
 pip install 'git+https://github.com/crate-workbench/cratedb-xlens.git'
+```
+
+Invoke using Docker or Podman.
+```shell
+docker run --rm --network=host ghcr.io/crate-workbench/cratedb-xlens
 ```
 
 ## Documentation

--- a/docs/oci.md
+++ b/docs/oci.md
@@ -1,5 +1,16 @@
 # OCI builds
 
+Public OCI images are available at this address.
+```text
+ghcr.io/crate-workbench/cratedb-xlens
+```
+
+Invoke using Docker or Podman.
+```shell
+docker run --rm --network=host ghcr.io/crate-workbench/cratedb-xlens
+```
+
+Build image locally.
 ```shell
 docker build --tag cratedb-xlens:local .
 ```

--- a/release/oci/selftest.sh
+++ b/release/oci/selftest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Fail on error.
+set -e
+
+# Display all commands.
+# set -x
+
+flavor=$1
+
+echo "Invoking program"
+xmover --version

--- a/release/oci/test.yml
+++ b/release/oci/test.yml
@@ -1,0 +1,7 @@
+services:
+  sut:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    entrypoint: ""
+    command: selftest.sh


### PR DESCRIPTION
For whatever reason, after merging GH-19, relevant commits did not appear on `main`. Is GitHub degrading? 💥 